### PR TITLE
Fixes channel avatar retrieval bug

### DIFF
--- a/internal/features/channel/service/service.go
+++ b/internal/features/channel/service/service.go
@@ -45,7 +45,7 @@ func (s *channelService) GetChannelAvatar(ctx context.Context, channelID int64) 
 		log.Printf("[DEBUG] Getting channel avatar for channel %d", channelID)
 	}
 
-	key := fmt.Sprintf(channelredis.ChannelAvatarKey, channelID)
+	key := fmt.Sprintf(channelredis.ChannelAvatarKey, strconv.FormatInt(channelID, 10))
 	avatarURL, err := s.redisClient.Get(ctx, key).Result()
 	if err != nil {
 		if err == redis.Nil {


### PR DESCRIPTION
Corrects key formatting for channel avatar retrieval by converting channel ID to string. Ensures proper redis cache key generation to prevent retrieval errors.
